### PR TITLE
Fix Nix packaging

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,16 +2,16 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1734991663,
-        "narHash": "sha256-8T660guvdaOD+2/Cj970bWlQwAyZLKrrbkhYOFcY1YE=",
+        "lastModified": 1784280462,
+        "narHash": "sha256-DtoqIqM7VkR6NxAkcLpMwmi02USwWb3JdmNGLyhthc0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "6c90912761c43e22b6fb000025ab96dd31c971ff",
+        "rev": "293d6abedf0478e681a4dfcfcb35b30fc796a32f",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-24.11",
+        "ref": "nixos-26.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "Fork of OpenStarbound and successor to xSB-2";
 
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-24.11";
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-26.05";
   };
 
   outputs =

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -13,7 +13,8 @@
   libopus,
   SDL2,
   glew,
-  xorg,
+  libsm,
+  libxi,
   ...
 }:
 let
@@ -83,11 +84,7 @@ let
     # the reason for why we have to do this is unknown. All other libraries gets automatically passed by
     # existing in nativeBuildInputs, but not libopus. This hack makes the build logs very noisy and it's not
     # very elegant, so if any future readers know what the issue might be, please improve this.
-    env.CXXFLAGS =
-      let
-        opusObjects = builtins.attrNames (builtins.readDir "${libopus}/lib");
-      in
-      "-Wl,-rpath ${lib.concatMapStringsSep " " (obj: "${libopus}/lib/${obj}") opusObjects}";
+    env.LDFLAGS = "-Wl,-rpath,${libopus}/lib -lopus";
 
     nativeBuildInputs = [
       cmake
@@ -99,9 +96,14 @@ let
       libopus
       SDL2
       glew
-      xorg.libSM
-      xorg.libXi
+      libsm
+      libxi
     ];
+
+    postPatch = ''
+      substituteInPlace CMakeLists.txt \
+        --replace-fail "-flto " ""
+    '';
 
     postInstall = ''
       mkdir -p "$out/bin"


### PR DESCRIPTION
* Update nixpkgs from 24.11 to 26.05

* Move linker flags from CXXFLAGS to LDFLAGS

* Disable Link Time Optimization (LTO)

_Fixes #50_